### PR TITLE
Do not append ?None if query string does not exist in a url.  At some po...

### DIFF
--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
@@ -20,7 +20,7 @@ class NewLoggingHandler(underlying: HttpService, options: LoggingOptions) extend
     val start = System.nanoTime()
 
     if(log.isInfoEnabled) {
-      val reqStr = req.method + " " + req.requestPathStr + Option(req.queryStr).fold("") { q =>
+      val reqStr = req.method + " " + req.requestPathStr + req.queryStr.fold("") { q =>
         "?" + q
       }
       val headers = options.logRequestHeaders.flatMap { hdr =>


### PR DESCRIPTION
...int, queryStr was changed to  an option.

NewLoggingHandler >>> GET /version
  vs
NewLoggingHandler >>> GET /version?None