### PR TITLE
Add support for specifying bind port and if we should bind to a specific address for liveness check.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,4 +42,8 @@ object Dependencies {
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
   val socrataUtils = "com.socrata" %% "socrata-utils" % "[0.8.0,1.0.0)"
+  val socrataThirdpartyUtils = "com.socrata" %% "socrata-thirdparty-utils" % "3.0.0"
+
+  val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
+
 }

--- a/project/SocrataHttpServer.scala
+++ b/project/SocrataHttpServer.scala
@@ -13,6 +13,8 @@ object SocrataHttpServer {
         scalaReflect(sv),
         simpleArm,
         slf4jApi,
+        socrataThirdpartyUtils,
+        typesafeConfig,
         scalaCheck % "test"
       )
     },

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
@@ -1,0 +1,10 @@
+package com.socrata.http.server.livenesscheck
+
+import com.socrata.thirdparty.typesafeconfig.ConfigClass
+import com.typesafe.config.Config
+
+class LivenessCheckConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val bindToAdvertisedInterface = getBoolean("bind-to-advertised-interface")
+  val port = getInt("port")
+  val address = getString("address")
+}

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
@@ -4,7 +4,10 @@ import com.socrata.thirdparty.typesafeconfig.ConfigClass
 import com.typesafe.config.Config
 
 class LivenessCheckConfig(config: Config, root: String) extends ConfigClass(config, root) {
-  val bindToAdvertisedInterface = getBoolean("bind-to-advertised-interface")
-  val port = getInt("port")
-  val address = getString("address")
+  /** Listen on port if specified, otherwise use ephemeral port. */
+  val port = optionally(getInt("port"))
+  /** Bind to address of the specific hostname or IP if specified, otherwise use wildcard. This should be set on
+    * systems with multiple interfaces on the same network or you may risk sending responses from the wrong IP.
+    */
+  val address = optionally(getString("address"))
 }

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
@@ -5,7 +5,7 @@ import scala.util.Random
 import java.nio.channels.spi.SelectorProvider
 import java.nio.{BufferOverflowException, ByteBuffer}
 import java.nio.channels.ClosedByInterruptException
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import java.io.{Closeable, IOException}
 import java.util.concurrent.CountDownLatch
 import java.nio.charset.StandardCharsets
@@ -15,6 +15,13 @@ import com.rojoma.simplearm.v2._
 import com.socrata.http.common.livenesscheck.LivenessCheckInfo
 
 class LivenessCheckResponder(address: InetSocketAddress, rng: Random = new Random) extends Closeable {
+  def this(config: LivenessCheckConfig) {
+    this(config.bindToAdvertisedInterface match {
+      case true => new InetSocketAddress(InetAddress.getByName(config.address), config.port)
+      case false => new InetSocketAddress(config.port)
+    })
+  }
+
   private val sendString = {
     val alphanum = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).mkString
     val sb = new StringBuilder

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
@@ -16,10 +16,10 @@ import com.socrata.http.common.livenesscheck.LivenessCheckInfo
 
 class LivenessCheckResponder(address: InetSocketAddress, rng: Random = new Random) extends Closeable {
   def this(config: LivenessCheckConfig) {
-    this(config.bindToAdvertisedInterface match {
-      case true => new InetSocketAddress(InetAddress.getByName(config.address), config.port)
-      case false => new InetSocketAddress(config.port)
-    })
+    this(new InetSocketAddress(config.address match {
+        case Some(addr) => InetAddress.getByName(addr)
+        case None => null
+      }, config.port.getOrElse(0)))
   }
 
   private val sendString = {

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckResponder.scala
@@ -16,10 +16,7 @@ import com.socrata.http.common.livenesscheck.LivenessCheckInfo
 
 class LivenessCheckResponder(address: InetSocketAddress, rng: Random = new Random) extends Closeable {
   def this(config: LivenessCheckConfig) {
-    this(new InetSocketAddress(config.address match {
-        case Some(addr) => InetAddress.getByName(addr)
-        case None => null
-      }, config.port.getOrElse(0)))
+    this(new InetSocketAddress(config.address.map(InetAddress.getByName).orNull, config.port.getOrElse(0)))
   }
 
   private val sendString = {


### PR DESCRIPTION
This is necessary to expose the liveness checker from docker containers.