### PR TITLE
Add basic auth in HttpClientHttpClient

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
@@ -53,7 +53,6 @@ class HttpClientHttpClient(executor: Executor, options: HttpClientHttpClient.Opt
       HttpClients.custom().
         disableAutomaticRetries().
         disableCookieManagement().
-        disableAuthCaching().
         setConnectionManager(connectionManager).
         setUserAgent(userAgent).
         setKeepAliveStrategy(DefaultConnectionKeepAliveStrategy.INSTANCE).
@@ -65,7 +64,8 @@ class HttpClientHttpClient(executor: Executor, options: HttpClientHttpClient.Opt
       case Some(creds) =>
         builder.setDefaultCredentialsProvider(creds)
         builder.addInterceptorFirst(new HttpClientHttpClient.BasicAuthRequestInterceptor(creds))
-      case None => // Explicit negative match as no auth is specified
+      case None =>  // Explicit negative match as no auth is specified, disable AuthCachin
+        builder.disableAuthCaching()
     }
 
     if(!contentCompression) builder.disableContentCompression()


### PR DESCRIPTION
In many backend services, our http client is tied to precisely ony
AuthScope and we wish to have BasicAuth against that host.  We could
set the header's and such on every request at the calling site, but I
think it would be cleaner to have this be set on the Apache HttpClient.

This commits creates an HttpRequestInterceptor that is added to the
HttpClient that uses the provided credentials provider and
well does basic auth.


This is a optimistic PR, as I am 
 1. Not certain if this is even a good idea
 2. Not 100% confident that I did this correctly


I have now used this code to issue authenticated requests to an internal BasicAuth Service and it worked wonderfully, but I could easily be missing something here. Currently, you have to define your authScope BEFORE your credentialsProvider in the `HttpClientHttpClient.Options` Builder, as well you just have to.

If this is a dumb idea, please do not hesitate to let me know or help me figure out a better idea.  This is what happens on Friday night at 1AM when I am frustrated with computers.