### PR TITLE
Use a QueuedThreadPool with a blocking queue by default

### DIFF
--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/SocrataServerJettyServlet.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/SocrataServerJettyServlet.scala
@@ -55,7 +55,8 @@ object SocrataServerJettyServlet {
     port: Int = AbstractSocrataServerJetty.defaultOptions.port,
     hookSignals: Boolean = AbstractSocrataServerJetty.defaultOptions.hookSignals,
     extraHandlers: List[Handler => Handler] = AbstractSocrataServerJetty.defaultOptions.extraHandlers,
-    errorHandler: Option[HttpRequest => HttpResponse] = None
+    errorHandler: Option[HttpRequest => HttpResponse] = None,
+    poolOptions: Pool.Options = AbstractSocrataServerJetty.defaultOptions.poolOptions
   ) extends Options {
     type OptT = OptionsImpl
 
@@ -72,8 +73,10 @@ object SocrataServerJettyServlet {
     override def withHookSignals(enabled: Boolean) = copy(hookSignals = enabled)
     override def withExtraHandlers(h: List[Handler => Handler]) = copy(extraHandlers = h)
     override def withErrorHandler(h: Option[HttpRequest => HttpResponse]) = copy(errorHandler = h)
+    override def withPoolOptions(pOpt: Pool.Options) = copy(poolOptions = pOpt)
   }
 
   val defaultOptions: Options = OptionsImpl()
   val Gzip = AbstractSocrataServerJetty.Gzip
+  val Pool = AbstractSocrataServerJetty.Pool
 }


### PR DESCRIPTION
This change prevents services -- particularly DB-related ones -- from
getting flooded by requests and paves a path towards surviving high loads.

Thinking about adding a test to test the boundedness, but it's nontrivial and wanted to get this out first.